### PR TITLE
Fix

### DIFF
--- a/admin/tab_m.html
+++ b/admin/tab_m.html
@@ -31,7 +31,7 @@
           }
       </style>
       <title>Device manager</title>
-    <script type="module" crossorigin src="./assets/app-os7epIdT.js"></script>
+    <script type="module" crossorigin src="./assets/app-DvVFWZj1.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/admin/tab_m.html
+++ b/admin/tab_m.html
@@ -24,9 +24,14 @@
               margin: 0;
               background-color: #f8f8f8;
           }
+          #root {
+              height: 100%;
+              width: 100%;
+              overflow: hidden;
+          }
       </style>
       <title>Device manager</title>
-    <script type="module" crossorigin src="./assets/app-xpw02iD9.js"></script>
+    <script type="module" crossorigin src="./assets/app-os7epIdT.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "node": ">= 16"
   },
   "dependencies": {
-    "@appland/appmap-agent-js": "^14.2.0",
     "@iobroker/adapter-core": "^3.0.4",
     "@jey-cee/dm-utils": "^0.0.5"
   },

--- a/src-admin/package.json
+++ b/src-admin/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "@iobroker/adapter-react-v5": "^4.7.11",
+    "@iobroker/adapter-react-v5": "4.7.11",
     "@types/react": "^18.2.42",
     "@types/react-dom": "^18.2.17",
     "@vitejs/plugin-react": "^4.2.1",


### PR DESCRIPTION
Got the device-manager working again:
![image](https://github.com/ioBroker/ioBroker.device-manager/assets/20473239/a8e8c0e7-8882-4167-8db9-ef6987cf2854)
![image](https://github.com/ioBroker/ioBroker.device-manager/assets/20473239/883f2a16-d5a3-43ce-a1a9-23dc6a780070)

- JsonConfigComponent is exported from separate package in @iobroker/adapter-react-v5 v5.x according to migration docs: 
https://github.com/ioBroker/adapter-react-v5?tab=readme-ov-file#migration-from-adapter-react-v54x-to-adapter-react-v55x, but apparently got already removed in a later 4.x version.
   - Workaround: fix @iobroker/adapter-react-v5 to an older version for now
- @appland/appmap-agent-js does not work with node v20. Just removed it, because i did not find any actual usage of this package in the adapter. Fixes https://github.com/ioBroker/ioBroker.device-manager/issues/42
=> rebuilt the adapter using npm run build in root